### PR TITLE
Problem with Underscore

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -1,6 +1,6 @@
 sys = require('sys')
 fs = require('fs')
-require('underscore')
+_ = require('underscore')
 
 # Search through a file and find all class definitions,
 # ignoring those in comments


### PR DESCRIPTION
I got the following error:

ReferenceError: _ is not defined
    at /Server/htdocs/colouredcontent/util/coffeescript-concat/coffeescript-concat.coffee:71:9
    at /Server/htdocs/colouredcontent/util/coffeescript-concat/coffeescript-concat.coffee:192:12
    at Object.<anonymous> (/Server/htdocs/colouredcontent/util/coffeescript-concat/coffeescript-concat.coffee:217:3)
    at Object.<anonymous> (/Server/htdocs/colouredcontent/util/coffeescript-concat/coffeescript-concat.coffee:218:4)
    at Module._compile (node.js:462:23)
    at Object.run (/usr/local/lib/node/.npm/coffee-script/1.0.0/package/lib/coffee-script.js:57:19)
    at /usr/local/lib/node/.npm/coffee-script/1.0.0/package/lib/command.js:120:29
    at /usr/local/lib/node/.npm/coffee-script/1.0.0/package/lib/command.js:83:26
    at fs:84:13
    at node.js:773:9

This commit fixes it by requiring underscore the right way :)
