### PR TITLE
Replaced console.log with sys.puts

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -180,7 +180,7 @@ concatenate = (sourceFiles, includeDirectories) ->
 
 	output = concatFiles(sourceFiles, deps)
 	output = removeDirectives(output)
-	console.log(output)
+	sys.puts(output)
 
 args = process.argv
 includeDirectories = []


### PR DESCRIPTION
I was having some problems with coffeescript files containing %s and %d.
After some help on #coffeescript IRC I noticed you used console.log instead of sys.puts.
Apparently console.log replaces %s and %d with undefined and NaN.
