### PR TITLE
makes command line arguments optional

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -218,9 +218,9 @@ describe('I', 'directory to search for files').
 alias('I', 'include-dir').
 describe('o', 'output file name').
 alias('o', 'output-file').
-demand(2).argv
+argv
 
-includeDirectories = argv.I
+includeDirectories = argv.I or []
 sourceFiles = argv._
 
 concatenate(sourceFiles, includeDirectories, argv.o)


### PR DESCRIPTION
Removes the requirement that 2 arguments must be passed in via
the command line. Since output file and include directories are both
optional, this is unnecessary.
