### PR TITLE
Bug fix so it is now possible to show help agian

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -210,17 +210,20 @@ concatenate = (sourceFiles, includeDirectories, outputFile) ->
 		util.puts(output)
 
 
-argv = require('optimist').
+options = require('optimist').
 usage("""Usage: coffeescript-concat [-I .] [-o outputfile.coffee] a.coffee b.coffee
 If no output file is specified, the resulting source will sent to stdout
 """).
+describe('h', 'display this help').
+alias('h','help').
 describe('I', 'directory to search for files').
 alias('I', 'include-dir').
 describe('o', 'output file name').
-alias('o', 'output-file').
-argv
+alias('o', 'output-file')
 
+argv = options.argv
 includeDirectories = argv.I or []
 sourceFiles = argv._
+if argv.help || (includeDirectories.length==0 && sourceFiles.length==0) then options.showHelp()
 
 concatenate(sourceFiles, includeDirectories, argv.o)


### PR DESCRIPTION
The last pull request you accepted made it so that help was no longer displayed if coffeescript-concat was called with no arguments. This pull request fixes that issue and adds another command line option, -h which forces the help to be shown.
