### PR TITLE
Added -R option to include directories recursively.

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -88,20 +88,22 @@ getFileNamesInDirsR = (dirs, filesFound, callback) ->
 		nextDir = dirs[dirs.length-1]
 		fs.readdir nextDir, (err, files) ->
 			directories = []
-			for file in files
-				filePath = nextDir.replace(/\/$/, '') + '/' + file
-				stats = fs.statSync filePath
-				if stats.isDirectory()
-					directories.push filePath
-				else if stats.isFile()
-					filesFound.push filePath
+			if err
+				throw err
+			else
+				for file in files
+					filePath = nextDir.replace(/\/$/, '') + '/' + file
+					stats = fs.statSync filePath
+					if stats.isDirectory()
+						directories.push filePath
+					else if stats.isFile()
+						filesFound.push filePath
 
-			dirs.splice dirs.length-1, 1
-			dirs = dirs.concat directories
+				dirs.splice dirs.length-1, 1
+				dirs = dirs.concat directories
 
-			getFileNamesInDirsR dirs, filesFound, (innerFilesFound) ->
-				callback innerFilesFound
-
+				getFileNamesInDirsR dirs, filesFound, (innerFilesFound) ->
+					callback innerFilesFound
 	else
 		callback filesFound
 


### PR DESCRIPTION
Hi,

I was using this library for one of my projects and felt that it missed the option to concatenate *.coffee files found in subdirectories, so I coded one.

Now you can use the -R option to include a folder recursively. 

I basically just used the fs.readdir function instead of its synchronous counterpart, the latter only lists out files, but not subfolders inside a given folder.

the -I option still includes files non-recursively.
