### PR TITLE
fs missing callback Error

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -251,7 +251,9 @@ concatenate = (sourceFiles, includeDirectories, includeDirectoriesRecursive, out
 		output = concatFiles(sourceFiles, deps)
 		output = removeDirectives(output)
 		if outputFile
-			fs.writeFile(outputFile, output)
+			fs.writeFile(outputFile, output, (err) ->
+				console.error err if err
+			)
 		else
 			util.puts(output)
 


### PR DESCRIPTION
nodejs on versions 0.10.0 and higher requires callback on all fs async function.

See https://github.com/joyent/node/issues/5005 for details.
