### PR TITLE
Fix recursive include

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -159,7 +159,12 @@ mapDependencies = (sourceFiles, searchDirectories, searchDirectoriesRecursive, c
 concatFiles = (sourceFiles, fileDefs) ->	
 	usedFiles = []
 	allFileDefs = fileDefs.slice(0)
-	sourceFileDefs = (fd for fd in fileDefs when fd.name in sourceFiles)
+
+	# if sourceFiles was not specified by user concat all files that we found in directory
+	if sourceFiles.length > 0
+		sourceFileDefs = (fd for fd in fileDefs when fd.name in sourceFiles)
+	else
+		sourceFileDefs = fileDefs
 
 	# Given a class name, find the file that contains that
 	# class definition.  If it doesn't exist or we don't know


### PR DESCRIPTION
There are two fixes:
1. Fix extern classes dependencies.
   Extern classes was removed from fileDef in commit 1793cb884b465e40aed15e55049ef6b0bad40816
   but it breaks dependencies resolving (no searching in extern classes)
2. Fix -R option.
   if we use command with -R option "coffeescript-concat -R ./src/" sourceFiles is empty array and in function concatFiles we get sourceFileDefs also empty (because of filtering based on sourceFiles). Now if sourceFiles is empty we will get all files in directory.
