### PR TITLE
Fix parsing classnames with dot

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -31,7 +31,7 @@ _ = require('underscore')
 #
 findClasses = (file) ->
 	file = '\n' + file
-	classRegex = /\n[^#\n]*class\s@?([A-Za-z_$-][A-Za-z0-9_$-]*)/g
+	classRegex = /\n[^#\n]*class\s@?([A-Za-z_$-][A-Za-z0-9_$-.]*)/g
 	
 	classNames = []
 	while (result = classRegex.exec(file)) != null


### PR DESCRIPTION
Add "." in regexp. (in findExternClasses's regep already exists)
