### PR TITLE
Do not consider "this" a class dependency

### DIFF
--- a/coffeescript-concat.coffee
+++ b/coffeescript-concat.coffee
@@ -58,7 +58,8 @@ findClassDependencies = (file) ->
 
 	dependencies = []
 	while (result = dependencyRegex.exec(file)) != null
-		dependencies.push(result[1])
+		if result[1] != "this"
+			dependencies.push(result[1])
 
 	file = file.replace(dependencyRegex, '')
 


### PR DESCRIPTION
Extending from "this" like

    class Foo extends this

is possible and sometimes useful.  Of course, "this" is no real
dependency: There is no file called "this.coffee" or similar.

This commit ignores "this" when collecting the class dependencies.